### PR TITLE
Simplify Dependabot configuration by removing updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,20 +16,8 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-      # major updates get individual PR
-      major-updates:
-        patterns:
-          - '*'
-        update-types:
-          - 'major'
-      # security updates get individual PR and are labeled as security updates
-      # applies-to: "security-updates" ensures this only applies to security vulnerabilities
-      security-updates:
-        patterns:
-          - '*'
-        applies-to: 'security-updates'
-
-  # GitHub Actions - alerts only, no auto-updates
+          
+  # GitHub Actions - PRs only, no auto-updates
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Removed major and security update configurations from Dependabot settings.