### PR TITLE
chore: keep React packages grouped in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,27 @@ updates:
       day: 'monday'
     # Groups define how Dependabot creates PRs for different update types
     groups:
+      # keep React runtime and types updated together
+      react-core:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+        update-types:
+          - 'minor'
+          - 'patch'
+
       # minor + patch updates in one PR
       # applies-to is version updated by default so does not need to be specified
       minor-and-patch:
         patterns:
           - '*'
+        exclude-patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
## Summary
Adds a Dependabot guardrail so React runtime and type packages are updated together.

## Changes
- Add `react-core` group for:
  - `react`
  - `react-dom`
  - `@types/react`
  - `@types/react-dom`
- Exclude those packages from the catch-all `minor-and-patch` group.

## Why
Prevents split patch bumps where `react-dom` advances ahead of `react`, which can trigger peer-resolution failures during CI dependency setup.

## Validation
- Config-only change in [.github/dependabot.yml](.github/dependabot.yml)
- No runtime code changes