### PR TITLE
chore: prevent Playwright package/docker version drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    ignore:
+      - dependency-name: '@playwright/test'
+        update-types:
+          - 'version-update:semver-patch'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-major'
     # Groups define how Dependabot creates PRs for different update types
     groups:
       # minor + patch updates in one PR

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,6 +35,9 @@ jobs:
           node-version: lts/*
           cache: 'npm'
 
+      - name: Validate Playwright version sync
+        run: npm run check:playwright-sync
+
       # Cache node_modules to avoid reinstalling in every downstream job
       - name: Cache node_modules
         uses: actions/cache@v6

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
+    "check:playwright-sync": "node scripts/check-playwright-version-sync.mjs",
     "dossier": "node --experimental-strip-types scripts/summarize-failure-dossier.ts",
     "type-check": "tsc --noEmit",
     "test": "playwright test --project=chromium --project=firefox --project=webkit",

--- a/scripts/check-playwright-version-sync.mjs
+++ b/scripts/check-playwright-version-sync.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const packageJsonPath = resolve(repoRoot, 'package.json');
+const workflowPath = resolve(repoRoot, '.github/workflows/cicd.yml');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const workflow = readFileSync(workflowPath, 'utf8');
+
+const playwrightSpec = packageJson.devDependencies?.['@playwright/test'];
+if (typeof playwrightSpec !== 'string') {
+  console.error('Missing devDependency: @playwright/test in package.json');
+  process.exit(1);
+}
+
+const versionMatch = playwrightSpec.match(/\d+\.\d+\.\d+/);
+if (!versionMatch) {
+  console.error(
+    `Could not parse a concrete version from @playwright/test spec: ${playwrightSpec}`,
+  );
+  process.exit(1);
+}
+
+const expectedVersion = versionMatch[0];
+const imageMatch = workflow.match(/mcr\.microsoft\.com\/playwright:v(\d+\.\d+\.\d+)-/);
+if (!imageMatch) {
+  console.error(
+    'Could not find Playwright Docker image tag in .github/workflows/cicd.yml',
+  );
+  process.exit(1);
+}
+
+const imageVersion = imageMatch[1];
+if (expectedVersion !== imageVersion) {
+  console.error(
+    [
+      'Playwright version mismatch detected:',
+      `- @playwright/test: ${playwrightSpec} (parsed ${expectedVersion})`,
+      `- Docker image: mcr.microsoft.com/playwright:v${imageVersion}-...`,
+      'Keep both values aligned in package.json and .github/workflows/cicd.yml.',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Playwright versions are in sync: @playwright/test=${expectedVersion}, image=v${imageVersion}`,
+);


### PR DESCRIPTION
## Summary
Adds guardrails to prevent CI failures caused by Playwright npm and Docker image version drift.

## Changes
- Add `check:playwright-sync` script in [package.json](package.json)
- Add sync validator script: [scripts/check-playwright-version-sync.mjs](scripts/check-playwright-version-sync.mjs)
- Run sync check early in CI setup in [.github/workflows/cicd.yml](.github/workflows/cicd.yml)
- Configure Dependabot to ignore automatic updates for `@playwright/test` in [.github/dependabot.yml](.github/dependabot.yml)

## Why
`@playwright/test` bumps can land without matching updates to the CI Docker image (`mcr.microsoft.com/playwright:vX.Y.Z-*`), causing repeat e2e pipeline failures.

## Validation
- Local run: `npm run check:playwright-sync`
- Current state verified as in-sync (`1.61.0`)