### PR TITLE
chore: add one-command playwright version bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-          
+
   # GitHub Actions - PRs only, no auto-updates
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "check:playwright-sync": "node scripts/check-playwright-version-sync.mjs",
+    "bump:playwright": "node scripts/bump-playwright-version.mjs",
     "dossier": "node --experimental-strip-types scripts/summarize-failure-dossier.ts",
     "type-check": "tsc --noEmit",
     "test": "playwright test --project=chromium --project=firefox --project=webkit",

--- a/scripts/bump-playwright-version.mjs
+++ b/scripts/bump-playwright-version.mjs
@@ -1,0 +1,47 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const packageJsonPath = resolve(repoRoot, 'package.json');
+const ciWorkflowPath = resolve(repoRoot, '.github/workflows/cicd.yml');
+
+const rawVersion = process.argv[2];
+if (!rawVersion) {
+  console.error('Usage: npm run bump:playwright -- <x.y.z>');
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(rawVersion)) {
+  console.error(`Invalid version "${rawVersion}". Expected format: x.y.z`);
+  process.exit(1);
+}
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+if (!packageJson.devDependencies || !packageJson.devDependencies['@playwright/test']) {
+  console.error('Missing devDependency: @playwright/test in package.json');
+  process.exit(1);
+}
+
+const previousNpmVersion = packageJson.devDependencies['@playwright/test'];
+packageJson.devDependencies['@playwright/test'] = `^${rawVersion}`;
+writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8');
+
+const workflowBefore = readFileSync(ciWorkflowPath, 'utf8');
+const imageRegex = /(mcr\.microsoft\.com\/playwright:v)(\d+\.\d+\.\d+)(-[^\s'"\n]+)/;
+const imageMatch = workflowBefore.match(imageRegex);
+
+if (!imageMatch) {
+  console.error(
+    'Could not find Playwright Docker image tag in .github/workflows/cicd.yml',
+  );
+  process.exit(1);
+}
+
+const previousImageVersion = imageMatch[2];
+const workflowAfter = workflowBefore.replace(imageRegex, `$1${rawVersion}$3`);
+writeFileSync(ciWorkflowPath, workflowAfter, 'utf8');
+
+console.log('Playwright versions updated.');
+console.log(`- @playwright/test: ${previousNpmVersion} -> ^${rawVersion}`);
+console.log(`- Docker image: v${previousImageVersion} -> v${rawVersion}`);
+console.log('Run `npm install` to refresh package-lock.json if needed.');


### PR DESCRIPTION
## Summary
Adds a one-command Playwright upgrade helper so package and CI Docker versions are updated together.

## Changes
- Add script entry in [package.json](package.json): `bump:playwright`
- Add updater script [scripts/bump-playwright-version.mjs](scripts/bump-playwright-version.mjs)
- Includes whitespace-only formatting in [.github/dependabot.yml](.github/dependabot.yml)

## Usage
- `npm run bump:playwright -- 1.62.0`

This updates:
- `devDependencies["@playwright/test"]` in [package.json](package.json)
- Playwright container image tag in [.github/workflows/cicd.yml](.github/workflows/cicd.yml)

## Validation
- `npm run check:playwright-sync`
- `npm run bump:playwright -- 1.61.0`